### PR TITLE
Add PEM export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,14 @@ File Location                       Subject
 Found 140 certificates
 ```
 
-### Global flags
+The `--output` (or `-o`) flag allows specifying the output mode for export.
 
-`-o --output`: Allows specification of the output mode. Supports `pretty`, `wide`, and `json`. Defaults to `pretty`.
+- `--output pretty` is the default, and gives a table view of the data.
+- `--output wide` also uses a table layout, but includes more infomation.
+- `--output json` emits JSON.
+- `--output pem` emits all full certificates in PEM format.
+
+### Global flags
 
 `--platform`: Specifies the platform in the form `os/arch[/variant][:osversion]` (e.g. `linux/amd64`)
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -119,6 +121,13 @@ func newExport(ctx context.Context) *cobra.Command {
 				}
 
 				fmt.Println(string(m))
+			} else if outOpts.Mode == options.OutputModePEM {
+				for _, cert := range parsedCertificates.Found {
+					pem.Encode(os.Stdout, &pem.Block{
+						Type:  "CERTIFICATE",
+						Bytes: cert.Certificate.Raw,
+					})
+				}
 			}
 
 			return nil

--- a/cmd/options/outputs.go
+++ b/cmd/options/outputs.go
@@ -13,9 +13,15 @@ const (
 	OutputModePretty = "pretty"
 	OutputModeJSON   = "json"
 	OutputModeWide   = "wide"
+	OutputModePEM    = "pem"
 )
 
-var outputModes = []string{OutputModePretty, OutputModeJSON, OutputModeWide}
+var outputModes = []string{
+	OutputModePretty,
+	OutputModeJSON,
+	OutputModeWide,
+	OutputModePEM,
+}
 
 // Output are options for configuring command outputs.
 type Output struct {


### PR DESCRIPTION
Add a new output mode to `paranoia export`, that when invoked with `--output pem` will emit all full certificates as a PEM bundle. This is then sutible for further investigation in other tools if desired.

closes #2 
